### PR TITLE
BFL endpoint supporting finetune

### DIFF
--- a/bfl_api.py
+++ b/bfl_api.py
@@ -9,7 +9,7 @@ from PIL import Image
 from requests.models import PreparedRequest
 import base64
 
-ROOT_API = "https://api.bfl.ml/"
+ROOT_API = "https://api.us1.bfl.ai/"
 API_KEY = os.environ.get("BFL_API_KEY")
 
 


### PR DESCRIPTION
Currently when attempting to use the new finetune feature in ComfyUI, the message:

```
BFL API Message: {'detail': 'Finetune not found or not ready'}
```

Is returned. This only seems to happen when calling the `https://api.bfl.ml` endpoints.

Based on the [official documentation](https://docs.bfl.ml/finetuning/) this feature uses a different API endpoint: `https://api.us1.bfl.ai/`

When making this change to the ROOT API location the feature works in ComfyUI